### PR TITLE
Stop travis doing 2 builds for one tag push - [ci skip] tag in commit…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_deploy:
 - git config --global user.email "builds@travis-ci.com"
 - git config --global user.name "Travis CI"
 - export GIT_TAG=v1.0.$TRAVIS_BUILD_NUMBER
-- git tag $GIT_TAG -a -m "Generated tag from TravisCI for build $TRAVIS_BUILD_NUMBER"
+- git tag $GIT_TAG -a -m "Generated tag from TravisCI for build $TRAVIS_BUILD_NUMBER [ci skip]"
 - git push -q https://${GH_TOKEN}@github.com/Stevie-Ray/apache-nginx-referral-spam-blacklist --tags
 - ls -aR
 deploy:


### PR DESCRIPTION
Fixes Travis incrementing build numbers incorrectly by 2 instead of 1.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Simply adds [ci skip] into commit message to stop Travis doing a subsequent build after the first build. Solves incrementing of build numbering by 2 instead of 1.

## Motivation and Context

Stop TravisCI doing a duplicate build after pushing tags.

## How Has This Been Tested?

Tested and solved after 100's of hours of testing on one of my test repo's. Finally discovered the magical [ci skip] tag. Hope this helps you as I learned my early beginnings of TravisCI from your repo.

## Screenshots (if appropriate):

## Types of changes

Simple change to commit message using [ci skip] tag

## Checklist:
